### PR TITLE
Fix bug import_comuni.py

### DIFF
--- a/comuni_italiani/management/commands/import_comuni.py
+++ b/comuni_italiani/management/commands/import_comuni.py
@@ -69,7 +69,7 @@ class Command(BaseCommand):
             # Nei dati del 2016 altitudine e superficie non sono stati inseriti
             # altitudine = locale.atoi(row['Altitudine del centro (metri)'])
             # superficie = locale.atof(row['Superficie territoriale (kmq) al 09/10/2011'])
-            popolazione = locale.atoi(row['Popolazione legale 2011 (09/10/2011)'])
+            popolazione = locale.atoi(row['Popolazione legale 2011 (09/10/2011)'].replace('.',''))
             citta_metropolitana_id = None
             try:
                 citta_metropolitana_id = int(row['Codice Città Metropolitana'])


### PR DESCRIPTION
Ciao Andrea, avrei fixato un bug che c'era nel file import_comuni.py, in quanto nel csv dei comuni il campo 'Popolazione legale 2011 (09/10/2011)' usa il '.' per separare le migliaia e così facendo non si produceva più una stringa di interi. 