### PR TITLE
Fix for django >= 4.0 makemigrations

### DIFF
--- a/comuni_italiani/apps.py
+++ b/comuni_italiani/apps.py
@@ -5,3 +5,4 @@ from django.apps import AppConfig
 class ComuniItalianiConfig(AppConfig):
     name = 'comuni_italiani'
     verbose_name = "Comuni Italiani"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
It's necessary to specify the default_auto_field param in apps.py to inhibit generation of migrations in package